### PR TITLE
Add paper 'Learning Deductive Reasoning from Synthetic Corpus based o…

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,6 +607,11 @@ Reasoning, as an essential ability for complex problem-solving, can provide back
 
     *Ben Prystawski, Noah D. Goodman.* [[abs](https://arxiv.org/abs/2304.03843)], 2023.4
 
+20. **Learning Deductive Reasoning from Synthetic Corpus based on Formal Logic.**
+
+    *Terufumi Morishita, Gaku Morio, Atsuki Yamaguchi, Yasuhiro Sogawa.* [[abs](https://arxiv.org/abs/2308.07336)], 2023.8
+
+
 
 ---
 
@@ -619,7 +624,7 @@ Reasoning, as an essential ability for complex problem-solving, can provide back
 | **Arithmetic Reasoning**  | [GSM8K](https://arxiv.org/abs/2110.14168), [SVAMP](https://aclanthology.org/2021.naacl-main.168), [ASDiv](https://aclanthology.org/2020.acl-main.92/), [AQuA-RAT](https://aclanthology.org/P17-1015/), [MAWPS](https://aclanthology.org/N16-1136/), [AddSub](https://aclanthology.org/D14-1058/), [MultiArith](https://aclanthology.org/D15-1202/), [SingleEq](https://aclanthology.org/Q15-1042/), [SingleOp]( https://doi.org/10.1162/tacl_a_00118) |
 | **Commonsense Reasoning** | [CommonsenseQA](https://aclanthology.org/N19-1421/), [StrategyQA](https://direct.mit.edu/tacl/article/doi/10.1162/tacl_a_00370/100680/Did-Aristotle-Use-a-Laptop-A-Question-Answering), [ARC](https://arxiv.org/abs/1803.05457), [SayCan](https://arxiv.org/abs/2204.01691), [BoolQA](https://aclanthology.org/N19-1300/), [HotpotQA](https://aclanthology.org/D18-1259/), [OpenBookQA](https://aclanthology.org/D18-1260/), [PIQA](https://yonatanbisk.com/piqa/), [WikiWhy](https://arxiv.org/abs/2210.12152) |
 |  **Symbolic Reasoning**   | [Last Letter Concatenation](https://arxiv.org/abs/2201.11903), [Coin Flip](https://arxiv.org/abs/2201.11903), Reverse List |
-|   **Logical Reasoning**   | [ProofWriter](https://arxiv.org/abs/2012.13048), [EntailmentBank](https://arxiv.org/abs/2104.08661), [RuleTaker](https://www.ijcai.org/proceedings/2020/537), [CLUTRR](https://aclanthology.org/D19-1458/) |
+|   **Logical Reasoning**   | [ProofWriter](https://arxiv.org/abs/2012.13048), [EntailmentBank](https://arxiv.org/abs/2104.08661), [RuleTaker](https://www.ijcai.org/proceedings/2020/537), [CLUTRR](https://aclanthology.org/D19-1458/), [FLD](https://arxiv.org/abs/2308.07336) |
 | **Multimodal Reasoning**  | [SCIENCEQA](https://scienceqa.github.io/)                    |
 |        **Others**         | [BIG-bench](https://doi.org/10.48550/arXiv.2206.04615), [SCAN](http://proceedings.mlr.press/v80/lake18a.html), [Chain-of-Thought Hub](https://arxiv.org/abs/2305.17306) |
 


### PR DESCRIPTION
Hi,

Thanks for the repository.
Could it be possible to add our paper "Learning Deductive Reasoning from Synthetic Corpus based on Formal Logic" (ICML2023).
In the paper, we proposed a logical deductive reasoning benchmark named FLD.
We also evaluated the performance of LLMs, such as GPT-4, GPT-3.5, under a setting of few-shot in-context learning _plus_ chain-of-thought prompting.

Best.